### PR TITLE
tmux-continuum run at startup on linux

### DIFF
--- a/scripts/handle_tmux_automatic_start.sh
+++ b/scripts/handle_tmux_automatic_start.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+UNAME="$(uname)"
 
 source "$CURRENT_DIR/helpers.sh"
 source "$CURRENT_DIR/variables.sh"
@@ -11,17 +12,25 @@ is_tmux_automatic_start_enabled() {
 }
 
 is_osx() {
-	[ $(uname) == "Darwin" ]
+	[ $UNAME == "Darwin" ]
+}
+
+is_linux() {
+	[ $UNAME == "Linux" ]
 }
 
 main() {
 	if is_tmux_automatic_start_enabled; then
 		if is_osx; then
 			"$CURRENT_DIR/handle_tmux_automatic_start/osx_enable.sh"
+		elif is_linux; then
+			"$CURRENT_DIR/handle_tmux_automatic_start/linux_enable.sh"
 		fi
 	else
 		if is_osx; then
 			"$CURRENT_DIR/handle_tmux_automatic_start/osx_disable.sh"
+		elif is_linux; then
+			"$CURRENT_DIR/handle_tmux_automatic_start/linux_disable.sh"
 		fi
 	fi
 }

--- a/scripts/handle_tmux_automatic_start/README.md
+++ b/scripts/handle_tmux_automatic_start/README.md
@@ -23,4 +23,11 @@ Config options:
 
 ### Linux
 
-Help with this would be greatly appreciated. Please get in touch.
+To enable this feature:
+- put `set -g @continuum-boot 'on'` in `tmux.conf`
+- reload tmux config with this shell command: `$ tmux source-file ~/.tmux.conf`
+
+Next time the computer is started:
+- `x-terminal-emulator` window will open
+- `tmux` command will be executed in the terminal window
+- if "auto restore" feature is enabled, tmux will start restoring previous env

--- a/scripts/handle_tmux_automatic_start/linux_disable.sh
+++ b/scripts/handle_tmux_automatic_start/linux_disable.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/../variables.sh"
+
+main() {
+	rm "$linux_auto_start_file_path" > /dev/null 2>&1
+}
+main

--- a/scripts/handle_tmux_automatic_start/linux_enable.sh
+++ b/scripts/handle_tmux_automatic_start/linux_enable.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# stub
+# =======
+# Need to place a startup script in /etc/rc.local (for Debian and/or Redhat based linuxes). Slackware based distros have the same file, but named something slightly
+# different.

--- a/scripts/handle_tmux_automatic_start/linux_shell_activator.sh
+++ b/scripts/handle_tmux_automatic_start/linux_shell_activator.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+"$@"
+exec "$SHELL"

--- a/scripts/handle_tmux_automatic_start/linux_terminal_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/linux_terminal_start_tmux.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# for "true full screen" call the script with "fullscreen" as the first argument
+TRUE_FULL_SCREEN="$1"
+TMUX="$(which tmux)"
+
+start_terminal_and_run_tmux() {
+	x-terminal-emulator -e ./linux_shell_activator.sh $TMUX
+}
+
+resize_window_to_full_screen() {
+	echo "Resize is up to terminal emulator being used." > /dev/null 2>&1
+}
+
+resize_to_true_full_screen() {
+	echo "Resize is up to terminal emulator being used." > /dev/null 2>&1
+}
+
+main() {
+	start_terminal_and_run_tmux
+	if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
+		resize_to_true_full_screen
+	else
+		resize_window_to_full_screen
+	fi
+}
+main


### PR DESCRIPTION
Started with adding tmux-continuum run at startup support for linux OSes. Given the diversity of linuxes, a larger effort will be required in getting a fully supported implementation working. As such, I've laid the basic groundwork that is effectively the same on all linuxes, (nixes for that matter) and what remains is implementing a cross platform startup scripting method. As an Ubuntu and CentOS user, I can do this for my OSes but I can't be certain that it will work across the board, and I'm certain it won't for any Slackware based distros.