### PR TITLE
added option to display continuum status in tmux status line

### DIFF
--- a/scripts/continuum_save.sh
+++ b/scripts/continuum_save.sh
@@ -34,9 +34,31 @@ fetch_and_run_tmux_resurrect_save_script() {
 	fi
 }
 
+output_current_continuum_status() {
+	save_int=$(get_tmux_option "$auto_save_interval_option" | sed  "s/[^0-9]*\([0-9]\+\).*/\1/")
+	status=""
+	if [ $save_int -eq 0 ]
+	then
+		status="#[fg=yellow]off#[fg=white]"
+	elif [ $save_int -gt 0 ]
+	then
+		status="#[fg=green,bold]"${save_int}"#[fg=white,nobold]"
+	else
+		status="#[fg=red]error#[fg=white]"
+	fi
+	local temp="#[fg=green,bold]"${save_int}"#[fg=white,nobold]"
+	echo " "${status}" "
+}
+
 main() {
 	if supported_tmux_version_ok && auto_save_not_disabled && enough_time_since_last_run_passed; then
 		fetch_and_run_tmux_resurrect_save_script
+	fi
+	
+	# if user has enabled show status option then insert into statusline
+	if [ -n $(get_tmux_option "$show_continuum_status_option" "") ]
+	then
+		output_current_continuum_status
 	fi
 }
 main

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -6,6 +6,7 @@ resurrect_restore_path_option="@resurrect-restore-script-path"
 
 auto_save_interval_option="@continuum-save-interval"
 auto_save_interval_default="15"
+show_continuum_status_option="@continuum-show-status-option"
 
 # time when the tmux environment was last saved (unix timestamp)
 last_auto_save_option="@continuum-save-last-timestamp"


### PR DESCRIPTION
This commit adds the ability to show the current  status of tmux-continuum and whether or not its enabled.
This does not change the default behaviour, it will only display the status if the user adds this to their `.tmux.conf`

    set  -g @continuum-show-status-option 'on'

The screenshots below show it in my customised tmux status line, but I think I have set it up so that it should work for most status lines.  

If tmux-continuum is off i.e. `continuum-save-interval` is set to `0` you will get something like this:

![continuum-status-off](https://cloud.githubusercontent.com/assets/9756341/11437546/76c568cc-9553-11e5-8aa3-23926d83bace.png)

If continuum is on it displays the current save interval in green.

![tmux-continuum-status-on](https://cloud.githubusercontent.com/assets/9756341/11437540/70bcb746-9553-11e5-9b6b-1aa894be348f.png)