### PR TITLE
added option: delete old continuum saves

### DIFF
--- a/scripts/continuum_save.sh
+++ b/scripts/continuum_save.sh
@@ -34,9 +34,19 @@ fetch_and_run_tmux_resurrect_save_script() {
 	fi
 }
 
+delete_old_saves() {
+	ls ${HOME}/.tmux/resurrect/* -1dtr | head -n -10 | xargs -d '\n' rm -f
+}
+
 main() {
 	if supported_tmux_version_ok && auto_save_not_disabled && enough_time_since_last_run_passed; then
 		fetch_and_run_tmux_resurrect_save_script
+	fi
+	
+	# if user has enabled @continuum-delete-old-saves-option 'on'
+	if [ -n $(get_tmux_option "$delete_old_saves_option" "") ]
+	then
+		delete_old_saves
 	fi
 }
 main

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -6,6 +6,7 @@ resurrect_restore_path_option="@resurrect-restore-script-path"
 
 auto_save_interval_option="@continuum-save-interval"
 auto_save_interval_default="15"
+delete_old_saves_option="@continuum-delete-old-saves-option"
 
 # time when the tmux environment was last saved (unix timestamp)
 last_auto_save_option="@continuum-save-last-timestamp"


### PR DESCRIPTION
Per the discussion on [this issue](https://github.com/tmux-plugins/tmux-continuum/issues/8) this commit adds the functionality to delete old tmux-continuum saves.
This code doesn't change  the default behaviour of continuum, but for those users who want to stop the `~/.tmux/resurrect` folder filling up with old save files, they can enable this by adding this line to `~/.tmux.conf`

    set -g @continuum-delete-old-saves-option 'on'



Note: the option uses this code provided by @gdebat, i.e.

    ls ~/.tmux/resurrect/* -1dtr | head -n -10 | xargs -d '\n' rm -f

It retains the last 7 saves  - but any additional saves beyond those 7 will be deleted.