### PR TITLE
#{continuum_status} status line interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   checking if other tmux server is running). Previously, this caused
   interpolation command not to be inserted into `status-right` because `tmux
   source-file` was falsely detected as another tmux server.
+- add `#{continuum_status}` status line interpolation
 
 ### v3.0.0, 2015-02-20
 - rename the plugin from `tmux-resurrect-auto` to `tmux-continuum`

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ required.
   this doc is safe to skip, but you might want to read it if you're using tmux
   with `-L` or `-S` flags
 - [automatically start tmux after the computer is turned on](docs/automatic_start.md)
+- [continuum status in tmux status line](docs/continuum_status.md)
 
 ### Other goodies
 

--- a/continuum.tmux
+++ b/continuum.tmux
@@ -56,6 +56,14 @@ start_auto_restore_in_background() {
 	"$CURRENT_DIR/scripts/continuum_restore.sh" &
 }
 
+update_tmux_option() {
+	local option="$1"
+	local option_value="$(get_tmux_option "$option")"
+	# replace interpolation string with a script to execute
+	local new_option_value="${option_value/$status_interpolation_string/$status_script}"
+	set_tmux_option "$option" "$new_option_value"
+}
+
 main() {
 	if supported_tmux_version_ok; then
 		handle_tmux_automatic_start
@@ -72,6 +80,11 @@ main() {
 		if just_started_tmux_server; then
 			start_auto_restore_in_background
 		fi
+
+		# Put "#{continuum_status}" interpolation in status-right or
+		# status-left tmux option to get current tmux continuum status.
+		update_tmux_option "status-right"
+		update_tmux_option "status-left"
 	fi
 }
 main

--- a/docs/continuum_status.md
+++ b/docs/continuum_status.md
@@ -1,0 +1,17 @@
+## Continuum status in tmux status line
+
+There is an option to display current status of tmux continuum in tmux status
+line. This is done via `#{continuum_status}` interpolation and it works with
+both `status-right` and `status-left` tmux native options.
+
+Example usage:
+
+    set -g status-right 'Continuum status: #{continuum_status}'
+
+When running, `#{continuum_status}` will show continuum save interval:
+
+    Continuum status: 15
+
+or if continuous saving is disabled:
+
+    Continuum status: off

--- a/scripts/continuum_status.sh
+++ b/scripts/continuum_status.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+source "$CURRENT_DIR/variables.sh"
+
+print_status() {
+	local save_int="$(get_tmux_option "$auto_save_interval_option")"
+	local status=""
+	local style_wrap
+	if [ $save_int -gt 0 ]; then
+		style_wrap="$(get_tmux_option "$status_on_style_wrap_option" "")"
+		status="$save_int"
+	else
+		style_wrap="$(get_tmux_option "$status_off_style_wrap_option" "")"
+		status="off"
+	fi
+
+	if [ -n "$style_wrap" ]; then
+		status="${style_wrap/$status_wrap_string/$status}"
+	fi
+	echo "$status"
+}
+print_status

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -25,3 +25,10 @@ auto_start_config_default=""
 
 osx_auto_start_file_name="Tmux.Start.plist"
 osx_auto_start_file_path="${HOME}/Library/LaunchAgents/${osx_auto_start_file_name}"
+
+status_interpolation_string="\#{continuum_status}"
+status_script="#($CURRENT_DIR/scripts/continuum_status.sh)"
+# below options set style/color for #{continuum_status} interpolation
+status_on_style_wrap_option="@continuum-status-on-wrap-style"   # example value: "#[fg=green]#{value}#[fg=white]"
+status_off_style_wrap_option="@continuum-status-off-wrap-style" # example value: "#[fg=yellow,bold]#{value}#[fg=white,nobold]"
+status_wrap_string="\#{value}"


### PR DESCRIPTION
Example use in tmux status line (left or right):

    set -g status-right 'Continuum status: #{continuum_status}'

Example styling when continuum is working:

    set -g @continuum-status-on-wrap-style '#[fg=green]#{value}#[fg=white]'

another example styling when continuum is NOT working:

    set -g @continuum-status-off-wrap-style '#[fg=yellow,bold]#{value}#[fg=white,nobold]'
