### PR TITLE
Mac OS X : update for iTerm2 >= 2.9

### DIFF
--- a/scripts/handle_tmux_automatic_start/osx_iterm_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_iterm_start_tmux.sh
@@ -3,6 +3,76 @@
 # for "true full screen" call the script with "fullscreen" as the first argument
 TRUE_FULL_SCREEN="$1"
 
+is_modern_iterm_version() {
+osascript >/dev/null<<-EOF
+on theSplit(theString, theDelimiter)
+    set oldDelimiters to AppleScript's text item delimiters
+    set AppleScript's text item delimiters to theDelimiter
+    set theArray to every text item of theString
+    set AppleScript's text item delimiters to oldDelimiters
+    return theArray
+end theSplit
+
+on IsModernVersion(version)
+	set myArray to my theSplit(version, ".")
+	set major to item 1 of myArray
+	set minor to item 2 of myArray
+	set veryMinor to item 3 of myArray
+	
+	if major < 2 then
+		return false
+	end if
+	if major > 2 then
+		return true
+	end if
+	if minor < 9 then
+		return false
+	end if
+	if minor > 9 then
+		return true
+	end if
+	if veryMinor < 20140903 then
+		return false
+	end if
+	return true
+end IsModernVersion
+
+tell application "iTerm"
+  return my IsModernVersion(version)
+end tell
+EOF
+}
+
+start_iterm29_and_run_tmux() {
+	osascript <<-EOF
+    tell application "iTerm"
+		#activate
+
+		# open iterm window
+		try
+			set _session to current session of current window
+		on error
+            try
+            -- if there is a profile named "tmux", then use it
+              set _term to (create window with profile "tmux")
+            on error
+            -- otherwise just use default profile...
+			  set _term to (create window with default profile)
+            end try
+			tell _term
+			    launch session "Tmux"
+				set _session to current session
+			end tell
+		end try
+
+		# start tmux
+		tell _session
+			 write text "tmux"
+		end tell
+    end tell
+	EOF
+}
+
 start_iterm_and_run_tmux() {
 	osascript <<-EOF
 	tell application "iTerm"
@@ -39,6 +109,16 @@ resize_window_to_full_screen() {
 	EOF
 }
 
+resize_iterm29_to_full_screen() {
+osascript <<-EOF
+tell application "iTerm"
+  tell window 1
+    set zoomed to true
+  end tell
+end tell
+EOF
+}
+
 resize_to_true_full_screen() {
 	osascript <<-EOF
 	tell application "iTerm"
@@ -55,12 +135,40 @@ resize_to_true_full_screen() {
 	EOF
 }
 
+resize_iterm29_to_true_full_screen() {
+	osascript <<-EOF
+	tell application "iTerm"
+		# wait for iTerm to start
+		delay 1
+		activate
+		# short wait for iTerm to gain focus
+		delay 0.1
+		# Command + Enter for fullscreen
+		tell application "System Events"
+			key code 36 using {command down}
+		end tell
+	end tell
+	EOF
+}
+
 main() {
-	start_iterm_and_run_tmux
-	if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
-		resize_to_true_full_screen
-	else
-		resize_window_to_full_screen
-	fi
+
+    # iTerm2 scripting changes in version ~2.9
+    # see https://iterm2.com/applescript.html
+    if is_modern_iterm_version; then 
+	  start_iterm29_and_run_tmux
+	  if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
+	  	  resize_iterm29_to_true_full_screen
+	  else
+	   	  resize_iterm29_to_full_screen
+	  fi
+    else
+	  start_iterm_and_run_tmux
+	  if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
+	  	  resize_to_true_full_screen
+	  else
+	   	  resize_window_to_full_screen
+	  fi
+    fi
 }
 main

--- a/scripts/handle_tmux_automatic_start/osx_iterm_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_iterm_start_tmux.sh
@@ -67,7 +67,7 @@ start_iterm29_and_run_tmux() {
 
 		# start tmux
 		tell _session
-			 write text "tmux"
+			 write text "tmux_start"
 		end tell
     end tell
 	EOF


### PR DESCRIPTION
Hi,

Looks like the recent iTerm2 (2.9) got different scripting capabilities. At least the version I have installed (Build 2.9.20160426) was not working with the vanilla osx_iterm_start_tmux.sh script. So I updated it. Hopefully I did not break it for older versions, but I actually did not test it. 

Note that I also introduced a small new "feature" in the script : if there is an already defined "tmux" profile in iTerm, then it is used, otherwise the default profile is used as before. That way I'm able to "style" my full screen tmux ;-) (e.g. font and background image, see attached screenshot).

<img width="1440" alt="capture d ecran 2016-05-01 a 19 09 46" src="https://cloud.githubusercontent.com/assets/1566009/14943090/55b73d70-0fd0-11e6-8f5f-39d68181aa4a.png">

Regards,
