### PR TITLE
systemd_enable.sh: is_enabled -> is-enabled

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -35,7 +35,7 @@ template() {
 }
 
 systemd_tmux_is_enabled() {
-	systemctl --user is_enabled $(basename "${systemd_unit_file_path}") >/dev/null 2>&1
+	systemctl --user is-enabled $(basename "${systemd_unit_file_path}") >/dev/null 2>&1
 }
 
 enable_tmux_unit_on_boot() {


### PR DESCRIPTION
Typo in systemctl check prevents tmux service to autostart.
