### PR TITLE
Fix num tmux process and continuum status

### DIFF
--- a/scripts/continuum_status.sh
+++ b/scripts/continuum_status.sh
@@ -6,7 +6,7 @@ source "$CURRENT_DIR/helpers.sh"
 source "$CURRENT_DIR/variables.sh"
 
 print_status() {
-	local save_int="$(get_tmux_option "$auto_save_interval_option")"
+	local save_int="$(get_tmux_option "$auto_save_interval_option" "$auto_save_interval_default")"
 	local status=""
 	local style_wrap
 	if [ $save_int -gt 0 ]; then

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -23,9 +23,11 @@ current_tmux_server_pid() {
 }
 
 all_tmux_processes() {
+	# search for "^tmux " cause there can be some other running scripts,
+	# whose name starts with "tmux" for eg "tmux-mem-cpu-load"
 	# ignores `tmux source-file .tmux.conf` command used to reload tmux.conf
 	ps -Ao "command pid" |
-		\grep "^tmux" |
+		\grep "^tmux " |
 		\grep -v "^tmux source"
 }
 


### PR DESCRIPTION
1) There can be other scripts whose name starts with tmux for eg
tmux-mem-cpu-load, because of this the
number_tmux_processes_except_current_server returned 2 even though there
was only 1 server(which it excludes) and 1 client.
2) By default continuum_status returned off even though the default
interval was 15 min.