### PR TITLE
Fix for multiple users on the same machine

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -24,7 +24,7 @@ current_tmux_server_pid() {
 
 all_tmux_processes() {
 	# ignores `tmux source-file .tmux.conf` command used to reload tmux.conf
-	ps -Ao "command pid" |
+	ps -u `whoami` -o "command pid" |
 		\grep "^tmux" |
 		\grep -v "^tmux source"
 }


### PR DESCRIPTION
The issue and fix are described in https://github.com/tmux-plugins/tmux-continuum/issues/16 .

Without this change, tmux-continuum works only for one tmux server on the machine. In a multi-user environment (e.g. a shared server), when multiple users are running their own tmux servers, this means that tmux-continuum works only for one of the users.

This change enables tmux-continuum for one tmux server per user instead of one tmux server per machine.