### PR TITLE
Refactor `all_tmux_processes`

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -23,10 +23,14 @@ current_tmux_server_pid() {
 }
 
 all_tmux_processes() {
-	# ignores `tmux source-file .tmux.conf` command used to reload tmux.conf
-	ps -Ao "command pid" |
-		\grep "^tmux" |
-		\grep -v "^tmux source"
+	# finds all tmux processes for the current user ignoring the following:
+  # 1) `tmux source-file .tmux.conf` (used to reload tmux.conf)
+  # 2) `tmux a` (which shows an additional process)
+
+  ps -Ao "command pid uid" |\
+    grep $UID |\
+    grep -E '^tmux' |\
+    grep -vE '^tmux\s+(a|source)'
 }
 
 number_tmux_processes_except_current_server() {


### PR DESCRIPTION
When counting the number of running tmux processes, count only those
that belong to the current user.

`tmux a` shows as a separate process (must be the client process) and
thus needs to be excluded from the calculation as well. The previous
exclusion of `tmux source` was also incorporated.