### PR TITLE
don't overwrite systemd unit file if it already exists

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -44,13 +44,27 @@ enable_tmux_unit_on_boot() {
 	fi
 }
 
-main() {
+systemd_unit_file() {
 	local options="$(get_tmux_option "$auto_start_config_option" "${auto_start_config_default}")"
 	local systemd_tmux_server_start_cmd="$(get_tmux_option "${systemd_tmux_server_start_cmd_option}" "${systemd_tmux_server_start_cmd_default}" )"
 	local tmux_start_script_path="${CURRENT_DIR}/linux_start_tmux.sh"
 	local systemd_unit_file=$(template "${tmux_start_script_path}" "${options}")
 	mkdir -p "$(dirname ${systemd_unit_file_path})"
-	echo "$systemd_unit_file" > "${systemd_unit_file_path}"
+	echo "$systemd_unit_file"
+}
+
+write_unit_file() {
+  systemd_unit_file > "${systemd_unit_file_path}"
+}
+
+write_unit_file_unless_exists() {
+	if ! [ -e "${systemd_unit_file_path}" ]; then
+    write_unit_file
+	fi
+}
+
+main() {
+  write_unit_file_unless_exists
 	enable_tmux_unit_on_boot
 }
 main


### PR DESCRIPTION
hey, sorry if i did the whole git/origin/merge/pull thing wrong, it's my first time please forgive me.

anyway, i didn't like how it was clobbering my 
.config/systemd/user/tmux.service 
so I fixed it to not do that anymore.

only writes the first time now, then you can edit the unit file as you please, like:
ExecStart=/usr/bin/tmux new-session -A -s hi -d

so it's not always starting a session [n], just the same default session every time.