### PR TITLE
Fix race condition in autosave

### DIFF
--- a/scripts/continuum_save.sh
+++ b/scripts/continuum_save.sh
@@ -35,8 +35,11 @@ fetch_and_run_tmux_resurrect_save_script() {
 }
 
 main() {
-	if supported_tmux_version_ok && auto_save_not_disabled && enough_time_since_last_run_passed; then
-		fetch_and_run_tmux_resurrect_save_script
-	fi
+	(
+		flock -n 101 || return  # The code below is not thread-safe.
+		if supported_tmux_version_ok && auto_save_not_disabled && enough_time_since_last_run_passed; then
+			fetch_and_run_tmux_resurrect_save_script
+		fi
+	) 101>/tmp/tmux-continuum-autosave.lockfile
 }
 main


### PR DESCRIPTION
Fixes the case where multiple tmux sessions call auto-save at the same time, which occasionally results in multiple instances of save_all() running in parallel and causing issues like #3 and tmux-plugins/tmux-resurrect#294.

The sequence in main() is:
1. Check enough_time_since_last_run_passed
2. Save
3. Update last_save_timestamp.

The race here is:
* process A finishes step 1 and is busy with step 2. The timestamp is not updated yet.
* process B comes to step 1, sees the old timestamp and proceeds to step 2, too.