### PR TITLE
Fix race condition in autosave

### DIFF
--- a/scripts/continuum_save.sh
+++ b/scripts/continuum_save.sh
@@ -36,7 +36,9 @@ fetch_and_run_tmux_resurrect_save_script() {
 
 main() {
 	(
-		flock -n 101 || return  # The code below is not thread-safe.
+		# The code after "flock" is not thread-safe. A race condition can be triggered by multiple
+		# tmux clients performing autosave in parallel.
+		! command -v flock || flock -n 101 || return
 		if supported_tmux_version_ok && auto_save_not_disabled && enough_time_since_last_run_passed; then
 			fetch_and_run_tmux_resurrect_save_script
 		fi

--- a/scripts/continuum_save.sh
+++ b/scripts/continuum_save.sh
@@ -35,8 +35,11 @@ fetch_and_run_tmux_resurrect_save_script() {
 }
 
 main() {
-	if supported_tmux_version_ok && auto_save_not_disabled && enough_time_since_last_run_passed; then
-		fetch_and_run_tmux_resurrect_save_script
-	fi
+	(
+		flock -n 101 || return  # The code below is not thread-safe.
+		if supported_tmux_version_ok && auto_save_not_disabled && enough_time_since_last_run_passed; then
+			fetch_and_run_tmux_resurrect_save_script
+		fi
+	) 101>/tmp/tmux-continuum-autosave.lockfile
 }
 main

--- a/scripts/continuum_save.sh
+++ b/scripts/continuum_save.sh
@@ -37,10 +37,11 @@ fetch_and_run_tmux_resurrect_save_script() {
 main() {
 	# Sometimes tmux starts multiple saves in parallel. We want only one
 	# save to be running, otherwise we can get corrupted saved state.
-	# The following implements a lock that auto-expires after 100...200s.
 	local lockdir_prefix="/tmp/tmux-continuum-$(current_tmux_server_pid)-lock-"
-	local lockdir1="${lockdir_prefix}$[ `date +%s` / 100 ]"
-	local lockdir2="${lockdir_prefix}$[ `date +%s` / 100 + 1]"
+	# The following implements a lock that auto-expires after 100...200s.
+	local lock_generation=$[ `date +%s` / 100 ]
+	local lockdir1="${lockdir_prefix}${lock_generation}"
+	local lockdir2="${lockdir_prefix}$[ $lock_generation + 1 ]"
 	if mkdir "$lockdir1"; then
 		trap "rmdir "$lockdir1"" EXIT
 		if mkdir "$lockdir2"; then


### PR DESCRIPTION
Handles the case where tmux starts multiple instances of auto-save in parallel  (see https://github.com/tmux-plugins/tmux-continuum/pull/61#issuecomment-508930136 for an example), which results in corrupted "last" file (issues like #3 and tmux-plugins/tmux-resurrect#294).

The sequence in main() is:
1. Check enough_time_since_last_run_passed
2. Save
3. Update last_save_timestamp.

The race here is:
* process A finishes step 1 and is busy with step 2. The timestamp is not updated yet.
* process B comes to step 1, sees the old timestamp and proceeds to step 2, too.