### PR TITLE
DON'T MERGE YET: Include more env var info.

### DIFF
--- a/docs/systemd_details.md
+++ b/docs/systemd_details.md
@@ -10,4 +10,12 @@ To control the tmux service you can use all the standard `systemctl` commands us
 
   systemctl --user status tmux.service
 
+## Note about environment variables (and desktop environments)
 
+tmux boots relatively early after login, and environment variables such as `DESKTOP_SESSION` are not available. A workaround for this is to allow this script to create the systemd unit as normal, and then disable it (meaning automatic start) with (`systemctl --user disable tmux.service`). After disabling it, add a line to `~/.xprofile` (create the file if it does not exist) with:
+
+```
+systemctl --user start tmux
+```
+
+This will achieve the same result, but the environment variables from the desktop environment should also be present.

--- a/docs/systemd_details.md
+++ b/docs/systemd_details.md
@@ -18,4 +18,6 @@ tmux boots relatively early after login, and environment variables such as `DESK
 systemctl --user start tmux
 ```
 
+Be sure to also remove the `set -g @continuum-boot 'on'` from your .tmux.conf. Otherwise, tmux-continuum will re-enable the service, and it will start before `~/.xprofile` is sourced.
+
 This will achieve the same result, but the environment variables from the desktop environment should also be present.


### PR DESCRIPTION
I had an issue where I needed `DESKTOP_SESSION` (I look for it in my `.bashrc` and set `SSH_AUTH_SOCK` to gnome-keyring's). I found a workaround on the web at https://daniel.perez.sh/blog/2018/user-systemd/ and thought I would add it here. I need to test it out a little more first, though, hence the "don't merge."