### PR TITLE
Use tpm's expected environment variable for the plugin dir

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -21,7 +21,7 @@ template() {
 	Environment=DISPLAY=:0
 	ExecStart=/usr/bin/tmux ${systemd_tmux_server_start_cmd}
 
-	ExecStop=${HOME}/.tmux/plugins/tmux-resurrect/scripts/save.sh
+	ExecStop=${TMUX_PLUGIN_MANAGER_PATH:-${HOME}/.tmux/plugins/}tmux-resurrect/scripts/save.sh
 	ExecStop=/usr/bin/tmux kill-server
 	KillMode=none
 


### PR DESCRIPTION
This fixes tmux-continuum for cases where the user has setup tpm to
install tmux plugins to a directory that is non-default (i.e:
"$XDG_CONFIG_HOME/tmux" instead of "$HOME/.tmux").

This allows the plugin to be more flexible based on the user's
configuration but still supports the default... by default.