### PR TITLE
feat: add kitty to the list of supported terminals for automatic start

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# https://editorconfig.org
+
+root = true
+
+[*.sh]
+charset = utf-8
+indent_style = tab
+indent_size = 7
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf

--- a/docs/automatic_start.md
+++ b/docs/automatic_start.md
@@ -16,10 +16,19 @@ Next time the computer is started:
 Config options:
 - `set -g @continuum-boot-options 'fullscreen'` - terminal window
   will go fullscreen
-- `set -g @continuum-boot-options 'iterm'` - start `iTerm` instead
+- `set -g @continuum-boot-options 'iterm'` - start [iTerm](https://www.iterm2.com) instead
   of `Terminal.app`
 - `set -g @continuum-boot-options 'iterm,fullscreen'` - start `iTerm`
   in fullscreen
+- `set -g @continuum-boot-options 'kitty'` - start [kitty](https://sw.kovidgoyal.net/kitty) instead
+  of `Terminal.app`
+- `set -g @continuum-boot-options 'kitty,fullscreen'` - start `kitty`
+  in fullscreen
+
+Note: The first time you reboot your machine and activate this feature you may be prompted about a script requiring
+access to a system program (i.e. - System Events). If this happens tmux will not start automatically and you will need
+to go to `System Preferences -> Security & Privacy -> Accessability` and add the script to the list of apps that are
+allowed to control your computer.
 
 ### Linux
 

--- a/scripts/handle_tmux_automatic_start/osx_enable.sh
+++ b/scripts/handle_tmux_automatic_start/osx_enable.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "$CURRENT_DIR/../helpers.sh"
 source "$CURRENT_DIR/../variables.sh"
 
 template() {
-	local tmux_start_script="$1"
-	local is_fullscreen="$2"
+  local tmux_start_script="$1"
+  local is_fullscreen="$2"
 
-	local fullscreen_tag=""
-	if [ "$is_fullscreen" == "true" ]; then
-		# newline and spacing so tag is aligned with other tags in template
-		fullscreen_tag=$'\n        <string>fullscreen</string>'
-	fi
+  local fullscreen_tag=""
+  if [ "$is_fullscreen" == "true" ]; then
+    # newline and spacing so tag is aligned with other tags in template
+    fullscreen_tag=$'\n        <string>fullscreen</string>'
+  fi
 
-	local content
-	read -r -d '' content <<-EOF
+  local content
+  read -r -d '' content <<- EOF
 	<?xml version="1.0" encoding="UTF-8"?>
 	<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 	<plist version="1.0">
@@ -32,35 +32,37 @@ template() {
 	</dict>
 	</plist>
 	EOF
-	echo "$content"
+  echo "$content"
 }
 
 get_iterm_or_teminal_option_value() {
-	local options="$1"
-	if [[ "$options" =~ "iterm" ]]; then
-		echo "iterm"
-	else
-		# Terminal.app is the default console app
-		echo "terminal"
-	fi
+  local options="$1"
+  if [[ "$options" =~ "iterm" ]]; then
+    echo "iterm"
+  elif [[ "$options" =~ "kitty" ]]; then
+    echo "kitty"
+  else
+    # Terminal.app is the default console app
+    echo "terminal"
+  fi
 }
 
 get_fullscreen_option_value() {
-	local options="$1"
-	if [[ "$options" =~ "fullscreen" ]]; then
-		echo "true"
-	else
-		echo "false"
-	fi
+  local options="$1"
+  if [[ "$options" =~ "fullscreen" ]]; then
+    echo "true"
+  else
+    echo "false"
+  fi
 }
 
 main() {
-	local options="$(get_tmux_option "$auto_start_config_option" "$auto_start_config_default")"
-	local iterm_or_terminal_value="$(get_iterm_or_teminal_option_value "$options")"
-	local fullscreen_option_value="$(get_fullscreen_option_value "$options")"
-	local tmux_start_script_path="${CURRENT_DIR}/osx_${iterm_or_terminal_value}_start_tmux.sh"
+  local options="$(get_tmux_option "$auto_start_config_option" "$auto_start_config_default")"
+  local iterm_or_terminal_value="$(get_iterm_or_teminal_option_value "$options")"
+  local fullscreen_option_value="$(get_fullscreen_option_value "$options")"
+  local tmux_start_script_path="${CURRENT_DIR}/osx_${iterm_or_terminal_value}_start_tmux.sh"
 
-	local launchd_plist_file_content="$(template "$tmux_start_script_path" "$fullscreen_option_value")"
-	echo "$launchd_plist_file_content" > "$osx_auto_start_file_path"
+  local launchd_plist_file_content="$(template "$tmux_start_script_path" "$fullscreen_option_value")"
+  echo "$launchd_plist_file_content" > "$osx_auto_start_file_path"
 }
 main

--- a/scripts/handle_tmux_automatic_start/osx_enable.sh
+++ b/scripts/handle_tmux_automatic_start/osx_enable.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_DIR/../helpers.sh"
 source "$CURRENT_DIR/../variables.sh"
 
 template() {
-  local tmux_start_script="$1"
-  local is_fullscreen="$2"
+	local tmux_start_script="$1"
+	local is_fullscreen="$2"
 
-  local fullscreen_tag=""
-  if [ "$is_fullscreen" == "true" ]; then
-    # newline and spacing so tag is aligned with other tags in template
-    fullscreen_tag=$'\n        <string>fullscreen</string>'
-  fi
+	local fullscreen_tag=""
+	if [ "$is_fullscreen" == "true" ]; then
+		# newline and spacing so tag is aligned with other tags in template
+		fullscreen_tag=$'\n        <string>fullscreen</string>'
+	fi
 
-  local content
-  read -r -d '' content <<- EOF
+	local content
+	read -r -d '' content <<-EOF
 	<?xml version="1.0" encoding="UTF-8"?>
 	<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 	<plist version="1.0">
@@ -32,37 +32,37 @@ template() {
 	</dict>
 	</plist>
 	EOF
-  echo "$content"
+	echo "$content"
 }
 
 get_iterm_or_teminal_option_value() {
-  local options="$1"
-  if [[ "$options" =~ "iterm" ]]; then
-    echo "iterm"
-  elif [[ "$options" =~ "kitty" ]]; then
-    echo "kitty"
-  else
-    # Terminal.app is the default console app
-    echo "terminal"
-  fi
+	local options="$1"
+	if [[ "$options" =~ "iterm" ]]; then
+		echo "iterm"
+	elif [[ "$options" =~ "kitty" ]]; then
+		echo "kitty"
+	else
+		# Terminal.app is the default console app
+		echo "terminal"
+	fi
 }
 
 get_fullscreen_option_value() {
-  local options="$1"
-  if [[ "$options" =~ "fullscreen" ]]; then
-    echo "true"
-  else
-    echo "false"
-  fi
+	local options="$1"
+	if [[ "$options" =~ "fullscreen" ]]; then
+		echo "true"
+	else
+		echo "false"
+	fi
 }
 
 main() {
-  local options="$(get_tmux_option "$auto_start_config_option" "$auto_start_config_default")"
-  local iterm_or_terminal_value="$(get_iterm_or_teminal_option_value "$options")"
-  local fullscreen_option_value="$(get_fullscreen_option_value "$options")"
-  local tmux_start_script_path="${CURRENT_DIR}/osx_${iterm_or_terminal_value}_start_tmux.sh"
+	local options="$(get_tmux_option "$auto_start_config_option" "$auto_start_config_default")"
+	local iterm_or_terminal_value="$(get_iterm_or_teminal_option_value "$options")"
+	local fullscreen_option_value="$(get_fullscreen_option_value "$options")"
+	local tmux_start_script_path="${CURRENT_DIR}/osx_${iterm_or_terminal_value}_start_tmux.sh"
 
-  local launchd_plist_file_content="$(template "$tmux_start_script_path" "$fullscreen_option_value")"
-  echo "$launchd_plist_file_content" > "$osx_auto_start_file_path"
+	local launchd_plist_file_content="$(template "$tmux_start_script_path" "$fullscreen_option_value")"
+	echo "$launchd_plist_file_content" > "$osx_auto_start_file_path"
 }
 main

--- a/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
@@ -4,44 +4,44 @@
 TRUE_FULL_SCREEN="$1"
 
 start_terminal_and_run_tmux() {
-  osascript <<- EOF
+	osascript <<-EOF
 	tell application "kitty"
 		activate
-    delay 5
-    tell application "System Events" to tell process "kitty"
-      set frontmost to true
-      keystroke "tmux"
-      key code 36
-    end tell
+		delay 5
+		tell application "System Events" to tell process "kitty"
+			set frontmost to true
+			keystroke "tmux"
+			key code 36
+		end tell
 	end tell
 	EOF
 }
 
 resize_window_to_full_screen() {
-  osascript <<- EOF
-tell application "kitty"
-	activate
-	tell application "System Events"
-		if (every window of process "kitty") is {} then
-			keystroke "n" using command down
-		end if
+	osascript <<-EOF
+	tell application "kitty"
+		activate
+		tell application "System Events"
+			if (every window of process "kitty") is {} then
+				keystroke "n" using command down
+			end if
 
-		tell application "Finder"
-			set desktopSize to bounds of window of desktop
+			tell application "Finder"
+				set desktopSize to bounds of window of desktop
+			end tell
+
+			set position of front window of process "kitty" to {0, 0}
+			set size of front window of process "kitty" to {item 3 of desktopSize, item 4 of desktopSize}
 		end tell
-
-		set position of front window of process "kitty" to {0, 0}
-		set size of front window of process "kitty" to {item 3 of desktopSize, item 4 of desktopSize}
 	end tell
-end tell
-EOF
+	EOF
 }
 
 resize_to_true_full_screen() {
-  osascript <<- EOF
+	osascript <<-EOF
 	tell application "kitty"
 		activate
-    delay 1
+		delay 1
 		tell application "System Events" to tell process "kitty"
 			keystroke "f" using {control down, command down}
 		end tell
@@ -50,11 +50,11 @@ resize_to_true_full_screen() {
 }
 
 main() {
-  start_terminal_and_run_tmux
-  if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
-    resize_to_true_full_screen
-  else
-    resize_window_to_full_screen
-  fi
+	start_terminal_and_run_tmux
+	if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
+		resize_to_true_full_screen
+	else
+		resize_window_to_full_screen
+	fi
 }
 main

--- a/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# for "true full screen" call the script with "fullscreen" as the first argument
+TRUE_FULL_SCREEN="$1"
+
+start_terminal_and_run_tmux() {
+  osascript <<- EOF
+	tell application "kitty"
+		activate
+    delay 5
+    tell application "System Events" to tell process "kitty"
+      set frontmost to true
+      keystroke "tmux"
+      key code 36
+    end tell
+	end tell
+	EOF
+}
+
+resize_window_to_full_screen() {
+  osascript <<- EOF
+tell application "kitty"
+	activate
+	tell application "System Events"
+		if (every window of process "kitty") is {} then
+			keystroke "n" using command down
+		end if
+
+		tell application "Finder"
+			set desktopSize to bounds of window of desktop
+		end tell
+
+		set position of front window of process "kitty" to {0, 0}
+		set size of front window of process "kitty" to {item 3 of desktopSize, item 4 of desktopSize}
+	end tell
+end tell
+EOF
+}
+
+resize_to_true_full_screen() {
+  osascript <<- EOF
+	tell application "kitty"
+		activate
+    delay 1
+		tell application "System Events" to tell process "kitty"
+			keystroke "f" using {control down, command down}
+		end tell
+	end tell
+	EOF
+}
+
+main() {
+  start_terminal_and_run_tmux
+  if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
+    resize_to_true_full_screen
+  else
+    resize_window_to_full_screen
+  fi
+}
+main


### PR DESCRIPTION
This is in response to #47

Since not all terminal emulators for mac have an applescript dictionary to code against it is non-trivial to implement a generic system to set and launch arbitrary terminal emulators on boot. That said, the OP mentioned supporting [kitty](https://sw.kovidgoyal.net/kitty) and this PR addresses exactly that.