### PR TITLE
Linux: Modifications to allow session restoration

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -19,7 +19,7 @@ template() {
 	[Service]
 	Type=forking
 	Environment=DISPLAY=:0
-	ExecStart=/usr/bin/tmux ${systemd_tmux_server_start_cmd}
+	ExecStart="${systemd_tmux_server_start_cmd_default}"
 
 	ExecStop=${HOME}/.tmux/plugins/tmux-resurrect/scripts/save.sh
 	ExecStop=/usr/bin/tmux kill-server

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -36,5 +36,6 @@ status_wrap_string="\#{value}"
 systemd_service_name="tmux.service"
 systemd_unit_file_path="$HOME/.config/systemd/user/${systemd_service_name}"
 
+tmux_server_session_temporary="tmux-continuum-tmp"
 systemd_tmux_server_start_cmd_option="@continuum-systemd-start-cmd"
-systemd_tmux_server_start_cmd_default="new-session -d"
+systemd_tmux_server_start_cmd_default="/usr/bin/tmux ${systemd_tmux_server_start_cmd} -s ${tmux_server_session_temporary} && /usr/bin/tmux kill-session -t ${tmux_server_session_temporary}"


### PR DESCRIPTION
The purpose of this modification is to allow session restoration on linux: the way are to :
- Create a labeled session "${tmux_server_session_temporary}" on start of tmux daemon 

Let plugin script "restore.sh" restore tmux session

- Clean restored session by remove the temporary session "${tmux_server_session_temporary}" which having served to load the tmux daemon

After the start of tmux daemon, start simply tmux with the following command in a terminal console :
`tmux a` / attach / attach-session
or automate the start of tmux in terminal with adding line to the .basrhrc user file:
`type tmux &>/dev/null && tmux ls &>/dev/null && [ -z $TMUX ] && [[ ! $TERM =~ screen ]] && tmux attach-session`

;o)