### PR TITLE
Delete stray lines at end of script

### DIFF
--- a/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
@@ -66,5 +66,3 @@ main() {
 	fi
 }
 main
-
-resize_to_


### PR DESCRIPTION
I'm not using this script, and I haven't looked very far into it, but based on the other scripts in this directory, I am guessing this line (which, I think, references a function that doesn't exist) was left in by accident.  This commit removes it.