### PR TITLE
Add option to set restore max delay

### DIFF
--- a/continuum.tmux
+++ b/continuum.tmux
@@ -46,7 +46,9 @@ add_resurrect_save_interpolation() {
 just_started_tmux_server() {
 	local tmux_start_time
 	tmux_start_time="$(tmux display-message -p -F '#{start_time}')"
-	[ "$tmux_start_time" == "" ] || [ "$tmux_start_time" -gt "$(($(date +%s)-10))" ]
+	local restore_max_delay
+	restore_max_delay="$(get_tmux_option "$auto_restore_max_delay_option" "${auto_restore_max_delay_default}")"
+	[ "$tmux_start_time" == "" ] || [ "$tmux_start_time" -gt "$(($(date +%s)-${restore_max_delay}))" ]
 }
 
 start_auto_restore_in_background() {

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -15,6 +15,9 @@ auto_restore_default="off"
 
 auto_restore_halt_file="${HOME}/tmux_no_auto_restore"
 
+auto_restore_max_delay_option="@continuum-restore-max-delay"
+auto_restore_max_delay_default="10"
+
 # tmux auto start options
 auto_start_option="@continuum-boot"
 auto_start_default="off"


### PR DESCRIPTION
Hi,

I've been having problems to automatically restore my previous sessions automatically. I've finally had some time to look into why this has been happening and in my specific case ([`.tmux.conf`](https://github.com/ahaasler/dotfiles/blob/280bdec49dbb96f10bd3284642874cf3dc6654f4/tmux/.tmux.conf)) the culprit is a slow loading plugin (tmux-remote-sessions), but this can also happen with a lot of enabled plugins or on a really slow machine. 

This may be the reason for other people having the same experience: #19 & #90

This PR makes the 10 seconds introduced in 4e2279688d8a577ed14f42c4e8af1acb58100a57 configurable with the option `@continuum-restore-max-delay`.