### PR TITLE
Improve systemd enable script

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -25,7 +25,7 @@ template() {
 
 	ExecStop=${resurrect_save_script_path}
 	ExecStop=${tmux_path} kill-server
-	KillMode=none
+	KillMode=control-group
 
 	RestartSec=2
 

--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -56,6 +56,8 @@ systemd_unit_file() {
 }
 
 write_unit_file() {
+	# it never hurts to make sure the directory we are writing into exists
+	mkdir -p "${systemd_config_path}"
   systemd_unit_file > "${systemd_unit_file_path}"
 }
 

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -37,7 +37,8 @@ status_off_style_wrap_option="@continuum-status-off-wrap-style" # example value:
 status_wrap_string="\#{value}"
 
 systemd_service_name="tmux.service"
-systemd_unit_file_path="$HOME/.config/systemd/user/${systemd_service_name}"
+systemd_config_path="$HOME/.config/systemd/user"
+systemd_unit_file_path="${systemd_config_path}/${systemd_service_name}"
 
 systemd_tmux_server_start_cmd_option="@continuum-systemd-start-cmd"
 systemd_tmux_server_start_cmd_default="new-session -d"


### PR DESCRIPTION
In trying to use continuum on ubuntu 21.10 I had 2 major problems 
the attempt to write the tmux.service file was to a directory that hadn't been created. I default to creating the path before we write, which should prevent this issue for others.

enabling the tmux service failed with a note about the KillMode - I've switched to [control-group which I think makes sense](https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=).