### PR TITLE
switch from which to command -v for tmux invoke

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -11,7 +11,7 @@ template() {
 	local options="$@"
 	local content=""
 	local resurrect_save_script_path="$(get_tmux_option "$resurrect_save_path_option" "$(realpath ${CURRENT_DIR}/../../../tmux-resurrect/scripts/save.sh)")"
-	local tmux_path="$(which tmux)"
+	local tmux_path="$(command -v tmux)"
 
 	read -r -d '' content <<-EOF
 	[Unit]


### PR DESCRIPTION
command -v is posix and on all systems, which isn't

Of course, this is probably a quibble as anything that has systemd on it
probably has which.

should resolve issue #46 