### PR TITLE
Fix systemd unit install on clean system

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -51,7 +51,6 @@ systemd_unit_file() {
 	local systemd_tmux_server_start_cmd="$(get_tmux_option "${systemd_tmux_server_start_cmd_option}" "${systemd_tmux_server_start_cmd_default}" )"
 	local tmux_start_script_path="${CURRENT_DIR}/linux_start_tmux.sh"
 	local systemd_unit_file=$(template "${tmux_start_script_path}" "${options}")
-	mkdir -p "$(dirname ${systemd_unit_file_path})"
 	echo "$systemd_unit_file"
 }
 
@@ -60,8 +59,13 @@ write_unit_file() {
 }
 
 write_unit_file_unless_exists() {
-	if ! [ -e "${systemd_unit_file_path}" ]; then
-    write_unit_file
+
+	local systemd_unit_file_dir=$(dirname ${systemd_unit_file_path})
+	if ! [ -d $systemd_unit_file_dir ]; then
+		mkdir -p $systemd_unit_file_dir
+		write_unit_file
+	elif ! [ -e "${systemd_unit_file_path}" ]; then
+    	write_unit_file
 	fi
 }
 


### PR DESCRIPTION
If the `.config/systemd/user` directory did not exist, it would not get created, as the `mkdir` command was inside the function `systemd_unit_file()` which is piped into the target file. 

The shell determined that file could not be created first (as the directory did not exist), so never called the function at all.
