### PR TITLE
For systemd, migrate from killmode=none to control-group

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -28,7 +28,7 @@ template() {
 
 	ExecStop=${resurrect_save_script_path}
 	ExecStop=${tmux_path} kill-server
-	KillMode=none
+	KillMode=control-group
 
 	RestartSec=2
 


### PR DESCRIPTION
KillMode=None is deprecated and will be discontinued.
control-group seems like the right choice in that it can kill all
underlying services appropriately and then we can restart them when the
tmux service is restarted.