### PR TITLE
Avoid overriding systemd unit/settings when not configured to do so

### DIFF
--- a/scripts/handle_tmux_automatic_start.sh
+++ b/scripts/handle_tmux_automatic_start.sh
@@ -18,17 +18,25 @@ is_systemd() {
 	[ $(ps -o comm= -p1) == 'systemd' ]
 }
 
+# Only manage the systemd unit either if it is not already installed, or if it
+# was installed by us (as signified by the magic comment)
+should_manage_systemd_unit() {
+	[ ! -f ${systemd_unit_file_path} ] \
+		&& \
+	systemctl cat --user ${systemd_service_name} | grep -q 'managed-by:tmux-continuum'
+}
+
 main() {
 	if is_tmux_automatic_start_enabled; then
 		if is_osx; then
 			"$CURRENT_DIR/handle_tmux_automatic_start/osx_enable.sh"
-		elif is_systemd; then
+		elif is_systemd && should_manage_systemd_unit; then
 			"$CURRENT_DIR/handle_tmux_automatic_start/systemd_enable.sh"
 		fi
 	else
 		if is_osx; then
 			"$CURRENT_DIR/handle_tmux_automatic_start/osx_disable.sh"
-		elif is_systemd; then
+		elif is_systemd && should_manage_systemd_unit; then
 			"$CURRENT_DIR/handle_tmux_automatic_start/systemd_disable.sh"
 		fi
 	fi

--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -17,6 +17,9 @@ template() {
 	local tmux_path="$(command -v tmux)"
 
 	read -r -d '' content <<-EOF
+	#managed-by:tmux-continuum
+	# This file is managed by the tmux-continuum plugin. Manual changes
+	# will be overridden.
 	[Unit]
 	Description=tmux default session (detached)
 	Documentation=man:tmux(1)


### PR DESCRIPTION
Fixes #121, #73.

Currently, if the user has their own tmux.service file and does not enable `continuum-boot`, tmux-continuum will disable it on startup. This PR adds a check to try to ensure it only makes changes if it matches the user intent to have it do so.