### PR TITLE
Update systemd_enable.sh

### DIFF
--- a/scripts/handle_tmux_automatic_start/systemd_enable.sh
+++ b/scripts/handle_tmux_automatic_start/systemd_enable.sh
@@ -23,7 +23,6 @@ template() {
 
 	[Service]
 	Type=forking
-	Environment=DISPLAY=:0
 	ExecStart=${tmux_path} ${systemd_tmux_server_start_cmd}
 
 	ExecStop=${resurrect_save_script_path}


### PR DESCRIPTION
Removed the explicitly-set `DISPLAY` variable as described in the following [issue](https://github.com/tmux-plugins/tmux-continuum/issues/127)

Fixes being unable to copy to clipboard with `xclip` after suspending / unsuspending.
After making this change I've been unable to reproduce the issue.

As I stated before I'm not very familiar with `x11` so it might not be the best solution, however it did solve the issue I was having.