### PR TITLE
Only add macOS .plist file if contents have changed

### DIFF
--- a/scripts/handle_tmux_automatic_start/osx_enable.sh
+++ b/scripts/handle_tmux_automatic_start/osx_enable.sh
@@ -65,6 +65,8 @@ main() {
 	local tmux_start_script_path="${CURRENT_DIR}/osx_${strategy}_start_tmux.sh"
 
 	local launchd_plist_file_content="$(template "$tmux_start_script_path" "$fullscreen_option_value")"
-	echo "$launchd_plist_file_content" > "$osx_auto_start_file_path"
+	if ! diff "$osx_auto_start_file_path" <(echo "$launchd_plist_file_content") &>/dev/null ; then
+		echo "$launchd_plist_file_content" > "$osx_auto_start_file_path"
+	fi
 }
 main


### PR DESCRIPTION
Saving this file triggers a notification saying that a background item was added. This happens on startup, every time. It is annoying.

Tested with:

- Existing file, same as template: no notification
- Existing file, different than template: notification, file added
- No file: notification, file added

Fixes: https://github.com/tmux-plugins/tmux-continuum/issues/118