### PR TITLE
#133 Warp terminal automatic startup

### DIFF
--- a/docs/automatic_start.md
+++ b/docs/automatic_start.md
@@ -27,6 +27,9 @@ Config options:
 - `set -g @continuum-boot-options 'alacritty'` - start [alacritty](https://github.com/alacritty/alacritty) instead of `Terminal.app`
 - `set -g @continuum-boot-options 'alacritty,fullscreen'` - start `alacritty`
   in fullscreen
+- `set -g @continuum-boot-options 'warp'` - start [warp](https://github.com/warpdotdev/Warp) instead of `Terminal.app`
+- `set -g @continuum-boot-options 'warp,fullscreen'` - start `warp`
+  in fullscreen
 
 Note: The first time you reboot your machine and activate this feature you may be prompted about a script requiring
 access to a system program (i.e. - System Events). If this happens tmux will not start automatically and you will need

--- a/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
@@ -40,8 +40,11 @@ resize_window_to_full_screen() {
 resize_to_true_full_screen() {
 	osascript <<-EOF
 	tell application "alacritty"
-		activate
+		# wait for alacritty to start
 		delay 1
+		activate
+		# short wait for alacritty to gain focus
+		delay 0.1
 		tell application "System Events" to tell process "alacritty"
 			keystroke "f" using {control down, command down}
 		end tell

--- a/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
@@ -54,9 +54,9 @@ resize_to_true_full_screen() {
 						set value of attribute "AXFullScreen" to true
 					end if
 				end tell
-			end if	
-        end tell
-    end tell
+			end if
+		end	tell
+	end	tell
 	EOF
 }
 

--- a/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
@@ -55,8 +55,8 @@ resize_to_true_full_screen() {
 					end if
 				end tell
 			end if
-		end	tell
-	end	tell
+		end tell
+	end tell
 	EOF
 }
 

--- a/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
@@ -7,7 +7,7 @@ start_terminal_and_run_tmux() {
 	osascript <<-EOF
 	tell application "alacritty"
 		activate
-		delay 0.5
+		delay 1
 		tell application "System Events" to tell process "alacritty"
 			set frontmost to true
 			keystroke "tmux"
@@ -39,19 +39,11 @@ resize_window_to_full_screen() {
 
 resize_to_true_full_screen() {
 	osascript <<-EOF
-	tell application "Alacritty"
+	tell application "alacritty"
 		activate
-		delay 0.5
-		tell application "System Events" to tell process "Alacritty"
-			if front window exists then
-				tell front window
-					if value of attribute "AXFullScreen" then
-						set value of attribute "AXFullScreen" to false
-					else
-						set value of attribute "AXFullScreen" to true
-					end if
-				end tell
-			end if
+		delay 1
+		tell application "System Events" to tell process "alacritty"
+			keystroke "f" using {control down, command down}
 		end tell
 	end tell
 	EOF

--- a/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
@@ -56,6 +56,7 @@ resize_to_true_full_screen() {
 				end tell
 			end if	
         end tell
+    end tell
 	EOF
 }
 

--- a/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_alacritty_start_tmux.sh
@@ -39,16 +39,23 @@ resize_window_to_full_screen() {
 
 resize_to_true_full_screen() {
 	osascript <<-EOF
-	tell application "alacritty"
+	tell application "Alacritty"
 		# wait for alacritty to start
 		delay 1
 		activate
 		# short wait for alacritty to gain focus
 		delay 0.1
-		tell application "System Events" to tell process "alacritty"
-			keystroke "f" using {control down, command down}
-		end tell
-	end tell
+		tell application "System Events" to tell process "Alacritty"
+			if front window exists then
+				tell front window
+					if value of attribute "AXFullScreen" then
+						set value of attribute "AXFullScreen" to false
+					else
+						set value of attribute "AXFullScreen" to true
+					end if
+				end tell
+			end if	
+        end tell
 	EOF
 }
 

--- a/scripts/handle_tmux_automatic_start/osx_enable.sh
+++ b/scripts/handle_tmux_automatic_start/osx_enable.sh
@@ -43,6 +43,8 @@ get_strategy() {
 		echo "kitty"
 	elif [[ "$options" =~ "alacritty" ]]; then
 		echo "alacritty"
+	elif [[ "$options" =~ "warp" ]]; then
+		echo "warp"
 	else
 		# Terminal.app is the default console app
 		echo "terminal"

--- a/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
@@ -40,8 +40,11 @@ resize_window_to_full_screen() {
 resize_to_true_full_screen() {
 	osascript <<-EOF
 	tell application "kitty"
-		activate
+		# wait for kitty to start
 		delay 1
+		activate
+		# short wait for kitty to gain focus
+		delay 0.1
 		tell application "System Events" to tell process "kitty"
 			keystroke "f" using {control down, command down}
 		end tell

--- a/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_kitty_start_tmux.sh
@@ -7,7 +7,7 @@ start_terminal_and_run_tmux() {
 	osascript <<-EOF
 	tell application "kitty"
 		activate
-		delay 5
+		delay 1
 		tell application "System Events" to tell process "kitty"
 			set frontmost to true
 			keystroke "tmux"

--- a/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
@@ -9,7 +9,7 @@ start_terminal_and_run_tmux() {
 	osascript <<-EOF
 	tell application "Warp"
 		activate
-		delay 5
+		delay 1
 		tell application "System Events" to tell process "Warp"
 			set frontmost to true
 			keystroke "tmux"

--- a/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
@@ -42,8 +42,11 @@ resize_window_to_full_screen() {
 resize_to_true_full_screen() {
 	osascript <<-EOF
 	tell application "Warp"
-		activate
+		# wait for Warp to start
 		delay 1
+		activate
+		# short wait for Warp to gain focus
+		delay 0.1
 		tell application "System Events" to tell process "Warp"
 			keystroke "f" using {control down, command down}
 		end tell

--- a/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
@@ -1,13 +1,15 @@
+# Maintainer: Dimitar Nizamov @dimitur2204 
+# Contact maintainer for any change to this file.
 #!/usr/bin/env bash
 
 # for "true full screen" call the script with "fullscreen" as the first argument
 TRUE_FULL_SCREEN="$1"
 
-start_Warp_and_run_tmux() {
+start_terminal_and_run_tmux() {
 	osascript <<-EOF
 	tell application "Warp"
 		activate
-		delay 2
+		delay 5
 		tell application "System Events" to tell process "Warp"
 			set frontmost to true
 			keystroke "tmux"
@@ -50,7 +52,7 @@ resize_to_true_full_screen() {
 }
 
 main() {
-	start_Warp_and_run_tmux
+	start_terminal_and_run_tmux
 	if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
 		resize_to_true_full_screen
 	else

--- a/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
@@ -9,7 +9,7 @@ start_warp_and_run_tmux() {
 		activate
 		delay 1
 		tell application "System Events" to tell process "warp"
-			keystroke "tmux attach"
+			keystroke "tmux"
 			key code 36
 		end tell
 	end tell

--- a/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
@@ -3,12 +3,13 @@
 # for "true full screen" call the script with "fullscreen" as the first argument
 TRUE_FULL_SCREEN="$1"
 
-start_warp_and_run_tmux() {
+start_Warp_and_run_tmux() {
 	osascript <<-EOF
-	tell application "warp"
+	tell application "Warp"
 		activate
-		delay 1
-		tell application "System Events" to tell process "warp"
+		delay 2
+		tell application "System Events" to tell process "Warp"
+			set frontmost to true
 			keystroke "tmux"
 			key code 36
 		end tell
@@ -18,10 +19,10 @@ start_warp_and_run_tmux() {
 
 resize_window_to_full_screen() {
 	osascript <<-EOF
-	tell application "warp"
+	tell application "Warp"
 		activate
 		tell application "System Events"
-			if (every window of process "warp") is {} then
+			if (every window of process "Warp") is {} then
 				keystroke "n" using command down
 			end if
 
@@ -29,8 +30,8 @@ resize_window_to_full_screen() {
 				set desktopSize to bounds of window of desktop
 			end tell
 
-			set position of front window of process "warp" to {0, 0}
-			set size of front window of process "warp" to {item 3 of desktopSize, item 4 of desktopSize}
+			set position of front window of process "Warp" to {0, 0}
+			set size of front window of process "Warp" to {item 3 of desktopSize, item 4 of desktopSize}
 		end tell
 	end tell
 	EOF
@@ -38,10 +39,10 @@ resize_window_to_full_screen() {
 
 resize_to_true_full_screen() {
 	osascript <<-EOF
-	tell application "warp"
+	tell application "Warp"
 		activate
 		delay 1
-		tell application "System Events" to tell process "warp"
+		tell application "System Events" to tell process "Warp"
 			keystroke "f" using {control down, command down}
 		end tell
 	end tell
@@ -49,7 +50,7 @@ resize_to_true_full_screen() {
 }
 
 main() {
-	start_warp_and_run_tmux
+	start_Warp_and_run_tmux
 	if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
 		resize_to_true_full_screen
 	else

--- a/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_warp_start_tmux.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# for "true full screen" call the script with "fullscreen" as the first argument
+TRUE_FULL_SCREEN="$1"
+
+start_warp_and_run_tmux() {
+	osascript <<-EOF
+	tell application "warp"
+		activate
+		delay 1
+		tell application "System Events" to tell process "warp"
+			keystroke "tmux attach"
+			key code 36
+		end tell
+	end tell
+	EOF
+}
+
+resize_window_to_full_screen() {
+	osascript <<-EOF
+	tell application "warp"
+		activate
+		tell application "System Events"
+			if (every window of process "warp") is {} then
+				keystroke "n" using command down
+			end if
+
+			tell application "Finder"
+				set desktopSize to bounds of window of desktop
+			end tell
+
+			set position of front window of process "warp" to {0, 0}
+			set size of front window of process "warp" to {item 3 of desktopSize, item 4 of desktopSize}
+		end tell
+	end tell
+	EOF
+}
+
+resize_to_true_full_screen() {
+	osascript <<-EOF
+	tell application "warp"
+		activate
+		delay 1
+		tell application "System Events" to tell process "warp"
+			keystroke "f" using {control down, command down}
+		end tell
+	end tell
+	EOF
+}
+
+main() {
+	start_warp_and_run_tmux
+	if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
+		resize_to_true_full_screen
+	else
+		resize_window_to_full_screen
+	fi
+}
+main


### PR DESCRIPTION
Fixes: #133

Added a `osx_warp_start_tmux.sh`, that uses the same implementation as `kitty` to open the warp terminal on startup.

Tested on:
MacBook Pro 16" M1 Pro 2021
Mac OS Sonoma - 14.3 (23D56)