### PR TITLE
WezTerm support

### DIFF
--- a/docs/automatic_start.md
+++ b/docs/automatic_start.md
@@ -27,6 +27,10 @@ Config options:
 - `set -g @continuum-boot-options 'alacritty'` - start [alacritty](https://github.com/alacritty/alacritty) instead of `Terminal.app`
 - `set -g @continuum-boot-options 'alacritty,fullscreen'` - start `alacritty`
   in fullscreen
+- `set -g @continuum-boot-options 'wezterm'` - start [wezterm](https://github.com/wez/wezterm) instead
+  of `Terminal.app`
+- `set -g @continuum-boot-options 'wezterm,fullscreen'` - start `wezterm`
+  in fullscreen
 
 Note: The first time you reboot your machine and activate this feature you may be prompted about a script requiring
 access to a system program (i.e. - System Events). If this happens tmux will not start automatically and you will need

--- a/scripts/handle_tmux_automatic_start/osx_enable.sh
+++ b/scripts/handle_tmux_automatic_start/osx_enable.sh
@@ -41,6 +41,8 @@ get_strategy() {
 		echo "iterm"
 	elif [[ "$options" =~ "kitty" ]]; then
 		echo "kitty"
+	elif [[ "$options" =~ "wezterm" ]]; then
+		echo "wezterm"
 	elif [[ "$options" =~ "alacritty" ]]; then
 		echo "alacritty"
 	else

--- a/scripts/handle_tmux_automatic_start/osx_wezterm_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_wezterm_start_tmux.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Maintainer: Fernando Silva @fcaraujo
+# # Contact maintainer for any change to this file.
+
 # for "true full screen" call the script with "fullscreen" as the first argument
 TRUE_FULL_SCREEN="$1"
 

--- a/scripts/handle_tmux_automatic_start/osx_wezterm_start_tmux.sh
+++ b/scripts/handle_tmux_automatic_start/osx_wezterm_start_tmux.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# for "true full screen" call the script with "fullscreen" as the first argument
+TRUE_FULL_SCREEN="$1"
+
+start_terminal_and_run_tmux() {
+	osascript <<-EOF
+	tell application "WezTerm"
+		activate
+		delay 1
+		tell application "System Events" to tell process "WezTerm"
+			set frontmost to true
+			keystroke "tmux"
+			key code 36
+		end tell
+	end tell
+	EOF
+}
+
+resize_window_to_full_screen() {
+	osascript <<-EOF
+	tell application "WezTerm"
+		activate
+		tell application "System Events"
+			if (every window of process "WezTerm") is {} then
+				keystroke "n" using command down
+			end if
+
+			tell application "Finder"
+				set desktopSize to bounds of window of desktop
+			end tell
+
+			set position of front window of process "WezTerm" to {0, 0}
+			set size of front window of process "WezTerm" to {item 3 of desktopSize, item 4 of desktopSize}
+		end tell
+	end tell
+	EOF
+}
+
+resize_to_true_full_screen() {
+	osascript <<-EOF
+	tell application "WezTerm"
+		activate
+		delay 1
+		tell application "System Events" to tell process "WezTerm"
+			if front window exists then
+				tell front window
+					if value of attribute "AXFullScreen" then
+						set value of attribute "AXFullScreen" to false
+					else
+						set value of attribute "AXFullScreen" to true
+					end if
+				end tell
+			end if
+		end tell
+	end tell
+	EOF
+}
+
+main() {
+	start_terminal_and_run_tmux
+	if [ "$TRUE_FULL_SCREEN" == "fullscreen" ]; then
+		resize_to_true_full_screen
+	else
+		resize_window_to_full_screen
+	fi
+}
+main


### PR DESCRIPTION
Adds WezTerm support at startup and fixes #137 

Tested with:
- wezterm only;
- wezterm in fullscreen.

On a Mac M2 with macOS Sonoma 14.6 (23G80).