### PR TITLE
Minor (but IMO critical) language update in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Features:
 
 - continuous saving of tmux environment
-- automatic tmux start when computer/server is turned on
+- automatic tmux start when computer/server is turned on and the user logs in
 - automatic restore when tmux is started
 
 Together, these features enable uninterrupted tmux usage. No matter the computer
 or server restarts, if the machine is on, tmux will be there how you left it off
-the last time it was used.
+the last time it was used once you log back in.
 
 Tested and working on Linux, OSX and Cygwin.
 

--- a/docs/automatic_start.md
+++ b/docs/automatic_start.md
@@ -1,6 +1,6 @@
 # Automatic Tmux start
 
-Tmux is automatically started after the computer/server is turned on.
+Tmux is automatically started after the user logs in.
 
 ### OS X
 
@@ -8,7 +8,7 @@ To enable this feature:
 - put `set -g @continuum-boot 'on'` in `.tmux.conf`
 - reload tmux config with this shell command: `$ tmux source-file ~/.tmux.conf`
 
-Next time the computer is started:
+Next time the computer is started and the user logs in:
 - `Terminal.app` window will open and resize to maximum size
 - `tmux` command will be executed in the terminal window
 - if "auto restore" feature is enabled, tmux will start restoring previous env
@@ -28,10 +28,12 @@ Config options:
 - `set -g @continuum-boot-options 'alacritty,fullscreen'` - start `alacritty`
   in fullscreen
 
-Note: The first time you reboot your machine and activate this feature you may be prompted about a script requiring
-access to a system program (i.e. - System Events). If this happens tmux will not start automatically and you will need
-to go to `System Preferences -> Security & Privacy -> Accessability` and add the script to the list of apps that are
-allowed to control your computer.
+Note: The first time you reboot your machine and activate this feature you may
+be prompted about a script requiring access to a system program (i.e. - System
+Events) upon first login. If this happens tmux will not start automatically and
+you will need to go to `System Preferences -> Security & Privacy ->
+Accessability` and add the script to the list of apps that are allowed to
+control your computer.  This may require administrative access.
 
 ### Linux
 


### PR DESCRIPTION
# tl;dr
Changed the language of the _README.md_ and *docs/automatic_start.md*:  `tmux-continuum` does **NOT** restore the `tmux` session on computer boot, but on user login, as far as I can tell, for both macOS and Linux.

# Longer explanation
I finally reread the `tmux-resurrect` _README.md_, and I saw mention of this `tmux-continuum` package.  I was highly intrigued, since several months ago I hacked together a goofy way to start `tmux` on login.  

Ultimately I got it working nicely, but it was a really kludgy hack.  Today I decided to break it to try and make it "better," and broke it all over again.  I think I ran into the same problem as before;  namely, `tmux-resurrect` starts so fast, that every `zsh` in my saved sessions seems to try and launch itself again;  it seems there's some kind of race condition and each zsh session tries to `tmux new-session -As ...` and I get the dreaded "sessions should be nested with care, unset $TMUX to force," which shouldn't be happening since I'm testing for the existence of `${TMUX}` and only trying to create/attach to the session only if it doesn't exist.

After reading the `tmux-continuum` _README.md_ I was disheartened, since it says once enabled, starts itself on computer boot.  This is actually what I *don't* want.  Actually, in my case (at least on Linux), I'm running systemd-homed, so it really *can't* start on computer boot.

When I started reading how this works, I discovered it's actually *exactly* what I want, at least on Linux, since it uses the systemd user mode.  It looks the same on macOS, but there a few reasons why I won't try that there yet.  Namely, my setup there is a lot more stable than Linux (since I have to use it for work), and my setup is pretty stable there already.  The other reason is I don't have admin/root access to that machine (I can get it with an IT helpdesk request, but only for five minutes, and it's always a pain to request it so I'd rather not).  I also hate launchd plists with a passion (XML is worse than YAML as a config file format, but they're both really effin' bad).

I actually haven't tried `tmux-continuum` yet, but I thought the language saying it started on computer boot is factually incorrect, and what are we nerds if not pedantic?